### PR TITLE
Snapshot Service Cleanup

### DIFF
--- a/packages/services/pkg/grpc/snapshot.go
+++ b/packages/services/pkg/grpc/snapshot.go
@@ -39,7 +39,7 @@ func (server *ecsSnapshotServer) GetStateLatest(ctx context.Context, in *pb.ECSS
 	if !snapshot.IsAvailableLatest(in.WorldAddress) {
 		return nil, fmt.Errorf("no snapshot")
 	}
-	latestSnapshot := snapshot.RawReadStateSnapshotLatest(in.WorldAddress)
+	latestSnapshot := snapshot.ReadPbStateLatest(in.WorldAddress)
 
 	return &pb.ECSStateReply{
 		State:           latestSnapshot.State,
@@ -57,7 +57,7 @@ func (server *ecsSnapshotServer) GetStateLatestStream(in *pb.ECSStateRequestLate
 	if !snapshot.IsAvailableLatest(in.WorldAddress) {
 		return fmt.Errorf("no snapshot")
 	}
-	latestSnapshot := snapshot.RawReadStateSnapshotLatest(in.WorldAddress)
+	latestSnapshot := snapshot.ReadPbStateLatest(in.WorldAddress)
 
 	// Respond in fraction chunks. If request has specified a chunk percentage, use that value.
 	chunkPercentage := server.config.DefaultSnapshotChunkPercentage
@@ -86,7 +86,7 @@ func (server *ecsSnapshotServer) GetStateLatestStreamPruned(request *pb.ECSState
 	if len(request.PruneAddress) == 0 {
 		return fmt.Errorf("address for which to prune for required")
 	}
-	latestSnapshot := snapshot.RawReadStateSnapshotLatest(request.WorldAddress)
+	latestSnapshot := snapshot.ReadPbStateLatest(request.WorldAddress)
 	latestSnapshotPruned := snapshot.PruneSnapshotOwnedByComponent(latestSnapshot, request.PruneAddress)
 
 	// Respond in fraction chunks. If request has specified a chunk percentage, use that value.
@@ -115,7 +115,7 @@ func (server *ecsSnapshotServer) GetStateBlockLatest(ctx context.Context, in *pb
 	if !snapshot.IsAvailableLatest(in.WorldAddress) {
 		return nil, fmt.Errorf("no snapshot")
 	}
-	latestSnapshot := snapshot.RawReadStateSnapshotLatest(in.WorldAddress)
+	latestSnapshot := snapshot.ReadPbStateLatest(in.WorldAddress)
 
 	return &pb.ECSStateBlockReply{
 		BlockNumber: latestSnapshot.EndBlockNumber,
@@ -134,7 +134,7 @@ func (server *ecsSnapshotServer) GetStateLatestStreamV2(in *pb.ECSStateRequestLa
 	if !snapshot.IsAvailableLatest(in.WorldAddress) {
 		return fmt.Errorf("no snapshot")
 	}
-	latestSnapshot := snapshot.RawReadStateSnapshotLatest(in.WorldAddress)
+	latestSnapshot := snapshot.ReadPbStateLatest(in.WorldAddress)
 
 	// Respond in fraction chunks. If request has specified a chunk percentage, use that value.
 	chunkPercentage := server.config.DefaultSnapshotChunkPercentage
@@ -163,7 +163,7 @@ func (server *ecsSnapshotServer) GetStateLatestStreamPrunedV2(request *pb.ECSSta
 	if len(request.PruneAddress) == 0 {
 		return fmt.Errorf("address for which to prune for required")
 	}
-	latestSnapshot := snapshot.RawReadStateSnapshotLatest(request.WorldAddress)
+	latestSnapshot := snapshot.ReadPbStateLatest(request.WorldAddress)
 	latestSnapshotPruned := snapshot.PruneSnapshotOwnedByComponent(latestSnapshot, request.PruneAddress)
 
 	// Respond in fraction chunks. If request has specified a chunk percentage, use that value.

--- a/packages/services/pkg/grpc/snapshot.go
+++ b/packages/services/pkg/grpc/snapshot.go
@@ -36,7 +36,7 @@ func (server *ecsSnapshotServer) GetWorlds(ctx context.Context, in *pb.WorldsReq
 // WorldAddress provided via ECSStateRequestLatest. The snapshot is sent as one object over the
 // wire.
 func (server *ecsSnapshotServer) GetStateLatest(ctx context.Context, in *pb.ECSStateRequestLatest) (*pb.ECSStateReply, error) {
-	if !snapshot.IsSnaphotAvailableLatest(in.WorldAddress) {
+	if !snapshot.IsAvailableLatest(in.WorldAddress) {
 		return nil, fmt.Errorf("no snapshot")
 	}
 	latestSnapshot := snapshot.RawReadStateSnapshotLatest(in.WorldAddress)
@@ -54,7 +54,7 @@ func (server *ecsSnapshotServer) GetStateLatest(ctx context.Context, in *pb.ECSS
 // WorldAddress provided via ECSStateRequestLatestStream. The snapshot is sent chunked via a stream over
 // the wire.
 func (server *ecsSnapshotServer) GetStateLatestStream(in *pb.ECSStateRequestLatestStream, stream pb.ECSStateSnapshotService_GetStateLatestStreamServer) error {
-	if !snapshot.IsSnaphotAvailableLatest(in.WorldAddress) {
+	if !snapshot.IsAvailableLatest(in.WorldAddress) {
 		return fmt.Errorf("no snapshot")
 	}
 	latestSnapshot := snapshot.RawReadStateSnapshotLatest(in.WorldAddress)
@@ -80,7 +80,7 @@ func (server *ecsSnapshotServer) GetStateLatestStream(in *pb.ECSStateRequestLate
 }
 
 func (server *ecsSnapshotServer) GetStateLatestStreamPruned(request *pb.ECSStateRequestLatestStreamPruned, stream pb.ECSStateSnapshotService_GetStateLatestStreamPrunedServer) error {
-	if !snapshot.IsSnaphotAvailableLatest(request.WorldAddress) {
+	if !snapshot.IsAvailableLatest(request.WorldAddress) {
 		return fmt.Errorf("no snapshot")
 	}
 	if len(request.PruneAddress) == 0 {
@@ -112,7 +112,7 @@ func (server *ecsSnapshotServer) GetStateLatestStreamPruned(request *pb.ECSState
 // GetStateLatestStream is a gRPC endpoint that returns the block number for the latest available
 // snapshot, if any, for a given WorldAddress provided via ECSStateBlockRequestLatest.
 func (server *ecsSnapshotServer) GetStateBlockLatest(ctx context.Context, in *pb.ECSStateBlockRequestLatest) (*pb.ECSStateBlockReply, error) {
-	if !snapshot.IsSnaphotAvailableLatest(in.WorldAddress) {
+	if !snapshot.IsAvailableLatest(in.WorldAddress) {
 		return nil, fmt.Errorf("no snapshot")
 	}
 	latestSnapshot := snapshot.RawReadStateSnapshotLatest(in.WorldAddress)
@@ -131,7 +131,7 @@ func (server *ecsSnapshotServer) GetStateAtBlock(ctx context.Context, in *pb.ECS
 //
 
 func (server *ecsSnapshotServer) GetStateLatestStreamV2(in *pb.ECSStateRequestLatestStream, stream pb.ECSStateSnapshotService_GetStateLatestStreamV2Server) error {
-	if !snapshot.IsSnaphotAvailableLatest(in.WorldAddress) {
+	if !snapshot.IsAvailableLatest(in.WorldAddress) {
 		return fmt.Errorf("no snapshot")
 	}
 	latestSnapshot := snapshot.RawReadStateSnapshotLatest(in.WorldAddress)
@@ -157,7 +157,7 @@ func (server *ecsSnapshotServer) GetStateLatestStreamV2(in *pb.ECSStateRequestLa
 }
 
 func (server *ecsSnapshotServer) GetStateLatestStreamPrunedV2(request *pb.ECSStateRequestLatestStreamPruned, stream pb.ECSStateSnapshotService_GetStateLatestStreamPrunedV2Server) error {
-	if !snapshot.IsSnaphotAvailableLatest(request.WorldAddress) {
+	if !snapshot.IsAvailableLatest(request.WorldAddress) {
 		return fmt.Errorf("no snapshot")
 	}
 	if len(request.PruneAddress) == 0 {

--- a/packages/services/pkg/snapshot/constants.go
+++ b/packages/services/pkg/snapshot/constants.go
@@ -2,9 +2,3 @@ package snapshot
 
 // SnapshotDir is the directory name for where the ECS snapshots are stored.
 const SnapshotDir string = "snapshots"
-
-// SerializedStateFilename is the name for the snapshot binary of ECS State.
-const SerializedStateFilename string = "./snapshots/SerializedECSState"
-
-// SerializedWorldsFilename is the name for the snapshot binary of Worlds.
-const SerializedWorldsFilename string = "./snapshots/SerializedWorlds"

--- a/packages/services/pkg/snapshot/encoder.go
+++ b/packages/services/pkg/snapshot/encoder.go
@@ -1,0 +1,170 @@
+package snapshot
+
+import (
+	"bytes"
+	"latticexyz/mud/packages/services/pkg/logger"
+	pb "latticexyz/mud/packages/services/protobuf/go/ecs-snapshot"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+func encodeState(state ECSState, startBlockNumber uint64, endBlockNumber uint64) []byte {
+	stateSnapshot := fromState(state, startBlockNumber, endBlockNumber)
+	encoding, err := proto.Marshal(stateSnapshot)
+	if err != nil {
+		logger.GetLogger().Error("failed to encode ECSState", zap.Error(err))
+	}
+	return encoding
+}
+
+func decodeState(encoding []byte) ECSState {
+	stateSnapshot := decode(encoding)
+	state := toState(stateSnapshot)
+	return state
+}
+
+// converts a state to a protobuf ECSStateSnapshot
+func fromState(state ECSState, startBlockNumber uint64, endBlockNumber uint64) *pb.ECSStateSnapshot {
+	stateSnapshot := &pb.ECSStateSnapshot{}
+
+	var rawStateBuffer bytes.Buffer
+	tsStart := time.Now()
+
+	// List of components and entities strings. We pad by one to avoid protobufs omitting
+	// our data.
+	components := []string{"0x0"}
+	entities := []string{"0x0"}
+
+	// Map of components / entities to their position in an array. This helps us
+	// assign the correct values to the ECSState slices as we build the snapshot.
+	componentToIdx := map[string]uint32{}
+	entitiyToIdx := map[string]uint32{}
+
+	// Indexes tracking the position of every component and entity in the array.
+	componentIdx := uint32(1)
+	entityIdx := uint32(1)
+
+	componentKeys := []string{}
+	for k := range state {
+		componentKeys = append(componentKeys, k)
+	}
+	sort.Strings(componentKeys)
+
+	for _, componentId := range componentKeys {
+		_state := state[componentId]
+
+		if _, ok := componentToIdx[componentId]; !ok {
+			components = append(components, componentId)
+			componentToIdx[componentId] = componentIdx
+			componentIdx++
+		}
+
+		entityKeys := []string{}
+		_state.Range(func(key, value interface{}) bool {
+			keyString, ok := key.(string)
+			if ok {
+				entityKeys = append(entityKeys, keyString)
+			}
+			return true
+		})
+
+		sort.Strings(entityKeys)
+
+		for _, entityId := range entityKeys {
+			value, ok := _state.Load(entityId)
+			if !ok {
+				logger.GetLogger().Error("did not find value in map for key", zap.String("key", entityId))
+				continue
+			}
+			valueBytes, ok := value.([]byte)
+			if !ok {
+				logger.GetLogger().Fatal("value data type expected to be []byte", zap.Any("value", value))
+			}
+
+			if _, ok := entitiyToIdx[entityId]; !ok {
+				entities = append(entities, entityId)
+				entitiyToIdx[entityId] = entityIdx
+				entityIdx++
+			}
+
+			stateSlice := &pb.ECSState{
+				ComponentIdIdx: componentToIdx[componentId],
+				EntityIdIdx:    entitiyToIdx[entityId],
+				Value:          valueBytes,
+			}
+			stateSnapshot.State = append(stateSnapshot.State, stateSlice)
+
+			rawStateBuffer.WriteString(componentId)
+			rawStateBuffer.WriteString(entityId)
+			rawStateBuffer.Write(valueBytes)
+		}
+	}
+
+	stateSnapshot.StateComponents = components
+	stateSnapshot.StateEntities = entities
+	stateSnapshot.StateHash = crypto.Keccak256Hash(rawStateBuffer.Bytes()).String()
+
+	stateSnapshot.StartBlockNumber = uint32(startBlockNumber)
+	stateSnapshot.EndBlockNumber = uint32(endBlockNumber)
+
+	tsElapsed := time.Since(tsStart)
+	logger.GetLogger().Info("computed hash of snapshot", zap.String("category", "Snapshot"), zap.String("keccak256Hash", stateSnapshot.StateHash), zap.String("timeTaken", tsElapsed.String()))
+
+	return stateSnapshot
+}
+
+// converts a protobuf ECSStateSnapshot to a state
+func toState(stateSnapshot *pb.ECSStateSnapshot) ECSState {
+	state := getEmptyState()
+
+	components := stateSnapshot.StateComponents
+	entities := stateSnapshot.StateEntities
+
+	for _, stateSlice := range stateSnapshot.State {
+		// First read the indexes from the snapshot, then lookup the actual
+		// component / entity id values from the array.
+		componentIdIdx := stateSlice.ComponentIdIdx
+		entityIdIdx := stateSlice.EntityIdIdx
+		value := stateSlice.Value
+
+		componentId := components[componentIdIdx]
+		entityId := entities[entityIdIdx]
+
+		if _, ok := state[componentId]; !ok {
+			state[componentId] = &sync.Map{}
+		}
+		state[componentId].Store(entityId, value)
+	}
+	return state
+}
+
+// decodes an encoded state file to a protobuf ECSStateSnapshot
+func decode(encoding []byte) *pb.ECSStateSnapshot {
+	stateSnapshot := &pb.ECSStateSnapshot{}
+	if err := proto.Unmarshal(encoding, stateSnapshot); err != nil {
+		logger.GetLogger().Error("failed to decode ECSState", zap.Error(err))
+	}
+	return stateSnapshot
+}
+
+func encodeWorldAddresses(worldAddresses []string) []byte {
+	worlds := worldAddressListToWorldsSnapshot(worldAddresses)
+	encoding, err := proto.Marshal(worlds)
+	if err != nil {
+		logger.GetLogger().Error("failed to encode World addresses", zap.Error(err))
+	}
+	return encoding
+}
+
+func decodeWorldAddresses(encoding []byte) *pb.Worlds {
+	worldsSnapshot := &pb.Worlds{}
+	if err := proto.Unmarshal(encoding, worldsSnapshot); err != nil {
+		logger.GetLogger().Error("failed to decode World addresses snapshot", zap.Error(err))
+	}
+	return worldsSnapshot
+}

--- a/packages/services/pkg/snapshot/encoder.go
+++ b/packages/services/pkg/snapshot/encoder.go
@@ -153,7 +153,7 @@ func decode(encoding []byte) *pb.ECSStateSnapshot {
 }
 
 func encodeWorldAddresses(worldAddresses []string) []byte {
-	worlds := worldAddressListToWorldsSnapshot(worldAddresses)
+	worlds := worldAddressesToPB(worldAddresses)
 	encoding, err := proto.Marshal(worlds)
 	if err != nil {
 		logger.GetLogger().Error("failed to encode World addresses", zap.Error(err))

--- a/packages/services/pkg/snapshot/io.go
+++ b/packages/services/pkg/snapshot/io.go
@@ -1,0 +1,60 @@
+package snapshot
+
+import (
+	"fmt"
+	"io/ioutil"
+	"latticexyz/mud/packages/services/pkg/logger"
+	"latticexyz/mud/packages/services/pkg/utils"
+
+	"go.uber.org/zap"
+)
+
+const (
+	StateFilename  string = "./snapshots/SerializedECSState" // prefix of the state snapshot filename
+	WorldsFilename string = "./snapshots/SerializedWorlds"   // name for the snapshot binary of Worlds
+)
+
+func getFilenameAtBlock(endBlockNumber uint64) string {
+	return fmt.Sprintf("%s-%d", StateFilename, endBlockNumber)
+}
+
+func getFilenameLatest(worldAddress string) string {
+	// Always lookup a snapshot with a checksummed address, since that is how they are written to
+	// disk.
+	return fmt.Sprintf("%s-latest-%s", StateFilename, utils.ChecksumAddressString(worldAddress))
+}
+
+func readStateAtBlock(blockNumber uint64) []byte {
+	return readState(getFilenameAtBlock(blockNumber))
+}
+
+func readStateLatest(worldAddress string) []byte {
+	return readState(getFilenameLatest(worldAddress))
+}
+
+func readState(fileName string) []byte {
+	encoding, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		logger.GetLogger().Fatal("failed to read encoded state", zap.String("fileName", fileName), zap.Error(err))
+	}
+	return encoding
+}
+
+func writeStateInitialSync(encoding []byte) {
+	filename := fmt.Sprintf("%s-initial-sync", StateFilename)
+	writeState(encoding, filename)
+}
+
+func writeStateAtBlock(encoding []byte, endBlockNumber uint64) {
+	writeState(encoding, getFilenameAtBlock(endBlockNumber))
+}
+
+func writeStateLatest(encoding []byte, worldAddress string) {
+	writeState(encoding, getFilenameLatest(worldAddress))
+}
+
+func writeState(encoding []byte, fileName string) {
+	if err := ioutil.WriteFile(fileName, encoding, 0644); err != nil {
+		logger.GetLogger().Fatal("failed to write ECSState", zap.String("fileName", fileName), zap.Error(err))
+	}
+}

--- a/packages/services/pkg/snapshot/start.go
+++ b/packages/services/pkg/snapshot/start.go
@@ -101,7 +101,7 @@ func Start(
 			// Take a snapshot every 'SnapshotBlockInterval' blocks.
 			if new(big.Int).Mod(blockNumber, snapshotInterval).Cmp(big.NewInt(0)) == 0 {
 				// TODO: update this to actually only take a snapshot of the selected worlds
-				go takeStateSnapshotChain(state, startBlock.Uint64(), blockNumber.Uint64(), Latest)
+				go createForAll(state, startBlock.Uint64(), blockNumber.Uint64(), Latest)
 			}
 		}
 	}

--- a/packages/services/pkg/snapshot/start.go
+++ b/packages/services/pkg/snapshot/start.go
@@ -49,6 +49,8 @@ func Start(
 		logger.Fatal("failed to subscribe to new blockchain head", zap.Error(err))
 	}
 
+	snapshotInterval := big.NewInt(config.SnapshotBlockInterval)
+
 	for {
 		select {
 		case err := <-sub.Err():
@@ -97,8 +99,8 @@ func Start(
 			state = reduceLogsIntoState(state, logsFiltered)
 
 			// Take a snapshot every 'SnapshotBlockInterval' blocks.
-			t := new(big.Int)
-			if t.Mod(blockNumber, big.NewInt(config.SnapshotBlockInterval)).Cmp(big.NewInt(0)) == 0 {
+			if new(big.Int).Mod(blockNumber, snapshotInterval).Cmp(big.NewInt(0)) == 0 {
+				// TODO: update this to actually only take a snapshot of the selected worlds
 				go takeStateSnapshotChain(state, startBlock.Uint64(), blockNumber.Uint64(), Latest)
 			}
 		}

--- a/packages/services/pkg/snapshot/state.go
+++ b/packages/services/pkg/snapshot/state.go
@@ -59,12 +59,12 @@ func getInitialStateChain() (ChainECSState, uint64) {
 
 func getInitialState(worldAddress string) (ECSState, uint64) {
 	// Check if a local snapshot is available, and if yes, sync from that.
-	if !IsSnaphotAvailableLatest(worldAddress) {
+	if !IsAvailableLatest(worldAddress) {
 		return getEmptyState(), 0
 	}
 
-	stateSnapshot := decodeSnapshot(readStateLatest(worldAddress))
-	return snapshotToState(stateSnapshot), uint64(stateSnapshot.EndBlockNumber)
+	stateSnapshot := decode(readStateLatest(worldAddress))
+	return toState(stateSnapshot), uint64(stateSnapshot.EndBlockNumber)
 }
 
 func createStateValue(state ECSState, componentId string) ECSState {

--- a/packages/services/pkg/snapshot/state.go
+++ b/packages/services/pkg/snapshot/state.go
@@ -33,7 +33,7 @@ func getInitialStateChain() (ChainECSState, uint64) {
 	// one-by-one. If there are no worlds that we know of, the initial state
 	// reduces to the empty state.
 	state := getEmptyStateChain()
-	worlds := readWorldAddressesSnapshot()
+	worlds := readWorlds()
 
 	var minBlockOfKnownECSState uint64 = math.MaxUint64
 	min := func(a, b uint64) uint64 {
@@ -63,7 +63,7 @@ func getInitialState(worldAddress string) (ECSState, uint64) {
 		return getEmptyState(), 0
 	}
 
-	stateSnapshot := decode(readStateLatest(worldAddress))
+	stateSnapshot := decode(readRawStateLatest(worldAddress))
 	return toState(stateSnapshot), uint64(stateSnapshot.EndBlockNumber)
 }
 

--- a/packages/services/pkg/snapshot/sync.go
+++ b/packages/services/pkg/snapshot/sync.go
@@ -63,7 +63,7 @@ func Sync(
 		time.Sleep(config.InitialSyncBlockBatchSyncTimeout)
 		// Take an in-progress snapshot up to the block number that has so far been loaded.
 		// if block%config.InitialSyncSnapshotInterval == 0 {
-		// 	go takeStateSnapshotChain(state, uint64(block), uint64(block+config.InitialSyncBlockBatchSize), InitialSync)
+		// 	go createForAll(state, uint64(block), uint64(block+config.InitialSyncBlockBatchSize), InitialSync)
 		// }
 	}
 
@@ -75,7 +75,7 @@ func Sync(
 
 	// Once the state is reduced, create a snapshot on disk which will later be merged with the
 	// up-to-date state.
-	go takeStateSnapshotChain(state, fromBlock.Uint64(), toBlock.Uint64(), InitialSync)
+	go createForAll(state, fromBlock.Uint64(), toBlock.Uint64(), InitialSync)
 
 	return state
 }


### PR DESCRIPTION
Still needs a fair amount of refactoring work to get this to a sane state, but it's at least
more readable with some function renaming and shuffling within the snapshot package. 
These changes are in preparation for us to split up the service into its Disk/Processing 
components on the cloud for greater resilience and faster recovery 
